### PR TITLE
Add GitHub Pages instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# Translation_Books
-Frequently updates of the translated text of some books.
+# Playground 翻译版
+
+该仓库收录 Richard Powers 的短篇小说 **Playground** 的中文译文（译者：Jolly Sammy）。所有章节以 PDF 的形式提供，并在 GitHub Pages 上展示。
+
+- 原作者网站：[https://www.richardpowers.net/](https://www.richardpowers.net/)
+
+## 在线阅读
+
+本仓库启用了 GitHub Pages，访问地址为：<https://your-username.github.io/translation-books.github.io/>（请将 `your-username` 替换为你的 GitHub 用户名）。
+
+无需克隆仓库，提交到 `main` 分支后 GitHub 会自动构建并发布网站。
+
+## 部署说明
+
+1. 进入仓库设置，启用 **GitHub Pages**，选择 `main` 分支和 `/` 根目录即可。
+2. GitHub 会在几分钟内自动构建并发布静态站点。
+
+站点主页会列出所有 PDF，每个文件都提供在线预览（浏览器直接打开）和本地下载两个链接。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Translation Books - Playground</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    h1 { text-align: center; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.5em; border-bottom: 1px solid #ccc; text-align: left; }
+    a { color: #0645ad; }
+  </style>
+</head>
+<body>
+  <h1>Playground Translation (中文)</h1>
+  <p>This site hosts the Chinese translation of Richard Powers's <em>Playground</em>, translated by Jolly Sammy.</p>
+  <table>
+    <thead>
+      <tr><th>PDF</th><th>View</th><th>Download</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Translation—Playground 1-2</td>
+        <td><a href="Translation—Playground_1-2.pdf" target="_blank">View</a></td>
+        <td><a href="Translation—Playground_1-2.pdf" download>Download</a></td>
+      </tr>
+      <tr>
+        <td>Translation—Playground 3-4</td>
+        <td><a href="Translation—Playground_3-4.pdf" target="_blank">View</a></td>
+        <td><a href="Translation—Playground_3-4.pdf" download>Download</a></td>
+      </tr>
+      <tr>
+        <td>Translation—Playground 5-6</td>
+        <td><a href="Translation—Playground_5-6.pdf" target="_blank">View</a></td>
+        <td><a href="Translation—Playground_5-6.pdf" download>Download</a></td>
+      </tr>
+      <tr>
+        <td>Translation—Playground 7-8</td>
+        <td><a href="Translation—Playground_7-8.pdf" target="_blank">View</a></td>
+        <td><a href="Translation—Playground_7-8.pdf" download>Download</a></td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- clarify that GitHub Pages automatically builds after pushing to `main`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684194f16a3c832d9b8d8221c311e86b